### PR TITLE
1-snake-food-feature

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -63,7 +63,7 @@ void move_snk(coord *pos, const snk_state dir);
 
 /* Updates the render of the snake in the screen */
 
-void update_scr(const coord pos);
+void update_scr(const coord pos, const coord food_pos);
 
 /* Returns a long long representing the number of miliseconds since an Epoch */
 

--- a/src/game.c
+++ b/src/game.c
@@ -51,9 +51,10 @@ void move_snk(coord *pos, const snk_state dir) {
     return;
 }
 
-void update_scr(const coord pos) {
+void update_scr(const coord pos, const coord food_pos) {
   wclear(win);
   mvwprintw(win, pos.y_pos, pos.x_pos, "%c", HEAD_CHAR);
+  mvwprintw(win, food_pos.y_pos, food_pos.x_pos, "%c", FOOD_CHAR);
   box(win, 0, 0);
   mvwprintw(win, 0, X_WIN_MAX / 2 - strlen(TITLE) / 2, "%s", TITLE);
   wrefresh(win);
@@ -66,7 +67,7 @@ long long now(void) {
 }
 
 void snake_food_gen(coord *position) {
-  srand(now());
-  position->x_pos = rand() % (X_WIN_MAX - 1) + 1;
-  position->y_pos = rand() % (Y_WIN_MAX - 1) + 1;
+
+  position->x_pos = rand() % (X_WIN_MAX - 2) + 1;
+  position->y_pos = rand() % (Y_WIN_MAX - 2) + 1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
 /* Formated with clang-format using LLVM conventions */
 
 int main(void) {
+  srand(now());
   char ch;
   coord head_pos; // TEMPORAL FOR TESTING POSITION OF SNAKE
   snk_state state = SNK_NAN;
@@ -20,14 +21,16 @@ int main(void) {
   box(win, 0, 0);
   head_pos.y_pos = Y_WIN_MAX / 2;
   head_pos.x_pos = X_WIN_MAX / 2;
-  update_scr(head_pos);
+  coord food_pos;
+  snake_food_gen(&food_pos);
+  update_scr(head_pos, food_pos);
   start = now();
   while (true) {
     CheckInput(wgetch(win), &state);
     end = now();
     if ((end - start) >= MOV_INTV && state != SNK_NAN) {
       move_snk(&head_pos, state);
-      update_scr(head_pos);
+      update_scr(head_pos, food_pos);
       start = end;
     }
   }


### PR DESCRIPTION
Seeds RNG at startup and renders food on screen by passing and drawing the food position. Generates food within inner playfield bounds to stay clear of borders and updates rendering calls to include the food coordinate accordingly.